### PR TITLE
Added OutputParser helper

### DIFF
--- a/gitlab-ci-runner/gitlab-ci-runner.csproj
+++ b/gitlab-ci-runner/gitlab-ci-runner.csproj
@@ -54,6 +54,7 @@
     <Compile Include="conf\Config.cs" />
     <Compile Include="helper\Command.cs" />
     <Compile Include="helper\PathHelper.cs" />
+    <Compile Include="helper\OutputParser.cs" />
     <Compile Include="helper\Win32IntegrityLevel.cs" />
     <Compile Include="helper\IniFile.cs" />
     <Compile Include="helper\Network.cs" />

--- a/gitlab-ci-runner/helper/Network.cs
+++ b/gitlab-ci-runner/helper/Network.cs
@@ -96,6 +96,9 @@ namespace gitlab_ci_runner.helper
         public static State pushBuild(int iId, State state, string sTrace)
         {
             State returnState = State.FAILED;
+            bool shrinkOutput = true;
+            bool printTestResults = false;
+
             var stateValue = "";
             if (state == State.RUNNING)
             {
@@ -104,6 +107,8 @@ namespace gitlab_ci_runner.helper
             else if (state == State.SUCCESS)
             {
                 stateValue = "success";
+                shrinkOutput = false;
+                printTestResults = true;
             }
             else if (state == State.FAILED)
             {
@@ -117,10 +122,14 @@ namespace gitlab_ci_runner.helper
             {
                 stateValue = "waiting";
             }
-            
-            var trace = new StringBuilder();
-            foreach (string t in sTrace.Split('\n'))
-                trace.Append(t).Append("\n");
+
+            if (state == State.SUCCESS || state == State.FAILED || state == State.ABORTED)
+            {
+                shrinkOutput = false;
+                printTestResults = true;
+            }
+
+            var trace = OutputParser.prettify(sTrace, shrinkOutput, printTestResults);
 
             int iTry = 0;
             try

--- a/gitlab-ci-runner/helper/OutputParser.cs
+++ b/gitlab-ci-runner/helper/OutputParser.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace gitlab_ci_runner.helper
+{
+    class OutputParser
+    {
+        public static StringBuilder prettify(string log, bool shrinkOutput, bool printTestResults)
+        {
+            StringComparison sco = StringComparison.CurrentCultureIgnoreCase;
+
+            StringBuilder returnValue = new StringBuilder();
+            bool NextLines = false;
+
+            int success = 0;
+            int failed = 0;
+            int ignored = 0;
+
+            string successpattern = @"Test:? .*? ==>? OK";
+            string failurepattern = @"Test:? .*? ==>? failed";
+            string ignoredpattern = @"Test:? .*? ==>? ignored";
+            string pattern = @"Test:? .*? ==>? (OK|failed|ignored)";
+
+            if (!String.IsNullOrEmpty(log))
+            {
+                foreach (string line in log.Split('\n'))
+                {
+                    if (shrinkOutput)
+                    {
+                        if (line.StartsWith("git ", sco)
+                        || line.StartsWith("--- ")
+                        || line.StartsWith("Starting Target:", sco)
+                        || line.StartsWith("Starting FinalTarget:", sco)
+                        || line.StartsWith("---------------------------------------------------------------------"))
+                            NextLines = true;
+
+                        if (NextLines)
+                            returnValue.Append(line).Append("\n");
+
+                        if (line.StartsWith("HEAD ", sco)
+                            || line.StartsWith("Finished Target", sco)
+                            || line.StartsWith("------ Target Test ------", sco)
+                            || line.StartsWith("--- enter runTestTargetBody() ---", sco)
+                            || line.StartsWith("Starting Target: FixLineBreaks", sco)
+                            || line.StartsWith("Starting FinalTarget:", sco))
+                            NextLines = false;
+                    }
+                    else
+                        returnValue.Append(line).Append("\n");
+
+                    if (printTestResults)
+                    {
+                        if (Regex.IsMatch(line, pattern))
+                        {
+                            MatchCollection mc = Regex.Matches(line, pattern);
+
+                            foreach (Match part in mc)
+                            {
+                                if (Regex.IsMatch(part.ToString(), successpattern))
+                                    success++;
+                                else if (Regex.IsMatch(part.ToString(), failurepattern))
+                                    failed++;
+                                else if (Regex.IsMatch(part.ToString(), ignoredpattern))
+                                    ignored++;
+                            }
+                        }
+                    }
+                }
+            }
+            if (printTestResults)
+            {
+                returnValue.Append("\n");
+                returnValue.Append(String.Format("---------------------------------------------------------------------\n"));
+                returnValue.Append(String.Format("Test results: {0} total, {1} success, {2} failed, {3} ignored\n", (success + failed + ignored), success, failed, ignored));
+                returnValue.Append(String.Format("---------------------------------------------------------------------\n"));
+            }
+            return returnValue;
+        }
+    }
+}

--- a/gitlab-ci-runner/helper/OutputParser.cs
+++ b/gitlab-ci-runner/helper/OutputParser.cs
@@ -70,6 +70,10 @@ namespace gitlab_ci_runner.helper
                     }
                 }
             }
+
+            if (shrinkOutput)
+                returnValue.Append("NOTE: detailed output is shown after the build finished.").Append("\n");
+
             if (printTestResults)
             {
                 returnValue.Append("\n");

--- a/gitlab-ci-runner/runner/Runner.cs
+++ b/gitlab-ci-runner/runner/Runner.cs
@@ -105,7 +105,7 @@ namespace gitlab_ci_runner.runner
             pushBuild();
 
             TimeSpan buildruntime = (DateTime.Now - buildstarttime);
-            Console.WriteLine("[{0}] Build {1} runtime : {2,2}h {3,2}min {4,2}sec", DateTime.Now, build.buildInfo.id, buildruntime.Hours, buildruntime.Minutes, buildruntime.Seconds);
+            Console.WriteLine("[{0}] Build {1} runtime: {2,2}h {3,2}min {4,2}sec", DateTime.Now, build.buildInfo.id, buildruntime.Hours, buildruntime.Minutes, buildruntime.Seconds);
             Console.WriteLine("----------------------------------------------------------");
 
             build.terminate();

--- a/gitlab-ci-runner/runner/Runner.cs
+++ b/gitlab-ci-runner/runner/Runner.cs
@@ -14,6 +14,7 @@ namespace gitlab_ci_runner.runner
         /// Build process
         /// </summary>
         private static Build build = null;
+        private static DateTime buildstarttime;
 
         /// <summary>
         /// Start the configured runner
@@ -22,6 +23,7 @@ namespace gitlab_ci_runner.runner
         {
             Console.WriteLine("* Gitlab CI Runner started");
             Console.WriteLine("* Waiting for builds");
+            Console.WriteLine("----------------------------------------------------------");
             waitForBuild();
         }
 
@@ -81,28 +83,30 @@ namespace gitlab_ci_runner.runner
             // Get build status
             State currentState = build.state;
 
+            Console.Write("[{0}] Build {1} ", DateTime.Now, build.buildInfo.id);
             if (currentState == State.SUCCESS)
             {
-                Console.WriteLine("[" + DateTime.Now.ToString() + "] Completed build " + build.buildInfo.id +".");
+                Console.WriteLine("completed.");
             }
             else if (currentState == State.FAILED)
             {
-                Console.WriteLine("[" + DateTime.Now.ToString() + "] Build " + build.buildInfo.id +" failed");
+                Console.WriteLine("failed.");
             }
             else if (currentState == State.ABORTED)
             {
-                Console.WriteLine("[" + DateTime.Now.ToString() + "] Build " + build.buildInfo.id + " was aborted.");
+                Console.WriteLine("was aborted.");
             }
             else
             {
-                Console.WriteLine("[" + DateTime.Now.ToString() + "] Something went wrong when completing build" + build.buildInfo.id + ".");
+                Console.WriteLine("... Something went wrong when completing build.");
             }
             
             // Push the final status
             pushBuild();
 
-            Console.WriteLine("--------------------------------------------------------");
-
+            TimeSpan buildruntime = (DateTime.Now - buildstarttime);
+            Console.WriteLine("[{0}] Build {1} runtime : {2,2}h {3,2}min {4,2}sec", DateTime.Now, build.buildInfo.id, buildruntime.Hours, buildruntime.Minutes, buildruntime.Seconds);
+            Console.WriteLine("----------------------------------------------------------");
 
             build.terminate();
             build = null;
@@ -162,6 +166,7 @@ namespace gitlab_ci_runner.runner
                 Thread t = new Thread(build.run);
                 t.Name = build.buildInfo.id.ToString();
                 t.Start();
+                buildstarttime = DateTime.Now;
             }
         }
     }

--- a/gitlab-ci-runner/setup/Setup.cs
+++ b/gitlab-ci-runner/setup/Setup.cs
@@ -30,7 +30,7 @@ namespace gitlab_ci_runner.setup
             String sCoordUrl = "";
             while (sCoordUrl == "")
             {
-                Console.WriteLine("Please enter the gitlab-ci coordinator URL (e.g. http(s)://gitlab-ci.org:3000/ )");
+                Console.WriteLine("Please enter the gitlab-ci coordinator URL (e.g. http(s)://gitlab-ci.org/ )");
                 sCoordUrl = Console.ReadLine();
             }
             Config.url = sCoordUrl;


### PR DESCRIPTION
- only push important trace output to the coordinator, while the build is running
- push the full trace only once when the build finished
- print test statistics when the build finished
